### PR TITLE
Replace className with classList to fix error on svg-click

### DIFF
--- a/addon/components/right-click-menu.js
+++ b/addon/components/right-click-menu.js
@@ -84,8 +84,8 @@ export default class RightClickMenuComponent extends Component {
       e &&
       !e.path.every((element) => {
         return (
-          !element.className ||
-          !element.className.includes('ember-right-click-menu__item')
+          !element.classList ||
+          !element.classList.contains('ember-right-click-menu__item')
         );
       })
     ) {


### PR DESCRIPTION
Hi, I have been using your addon since lately and I am very happy with it so far. Unfortunately I noticed that clicking on SVG elements throws an error and the menu does not close. ("Error: element.className.includes is not a function")

I looked at the appropriate place in the code and found out that the classList attributes of HTML and SVG elements have different meanings.

See also this comment: https://stackoverflow.com/a/37949156

Therefore I would suggest to work with classList instead of className.